### PR TITLE
Add Rust spy CLI and CI workflow

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,0 +1,28 @@
+name: Rust CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run cargo fmt
+        run: cargo fmt --manifest-path spy-cli/Cargo.toml -- --check
+
+      - name: Run cargo clippy
+        run: cargo clippy --manifest-path spy-cli/Cargo.toml --all-targets --all-features -- -D warnings
+
+      - name: Run cargo test
+        run: cargo test --manifest-path spy-cli/Cargo.toml --all-targets

--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,9 @@ wheelhouse/
 .build/
 Package.resolved
 
+### Rust ###
+target/
+
 # intellij
 .idea/
 *.DotSettings.user

--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ PlatynUI.Spy
 - Identify elements and properties in your application
 - Access elements with it's properties and build locators to access and simulate ui applications
 
+### Rust Command-Line Spy
+
+- Build the Rust-based spy utility inside this repository for scripted inspection workflows:
+
+  ```console
+  cargo run --manifest-path spy-cli/Cargo.toml -- --input path/to/tree.json --role button --include-properties
+  ```
+- Pipe JSON dumps into the process (or provide an input path) to receive a filtered UI tree on stdout.
+- Combine options such as `--name-pattern`, `--property key=value`, and `--max-depth` to narrow the output to the elements you need.
+
 ## Demo
 
 - [Robocon 2025](https://www.youtube.com/watch?v=H3gOjp1VZWQ)

--- a/docs/spy_tool_plan.md
+++ b/docs/spy_tool_plan.md
@@ -1,0 +1,42 @@
+# Rust Spy Tool Implementation Plan
+
+## 1. Background and Existing Capabilities
+- The repository already ships a graphical spy utility built with Avalonia that is launched via the `PlatynUI.Spy` desktop application entry point.【F:README.md†L55-L81】【F:src/PlatynUI.Spy/Program.cs†L1-L20】
+- The GUI tool focuses on interactively inspecting running applications; a command-line complement is missing for scripted pipelines or headless environments.【F:README.md†L55-L81】
+
+## 2. Objectives for the Command-Line Spy Tool
+- Provide a Rust-based binary (`spy-cli`) that can be executed in CI or local shells without a window system.
+- Accept serialized UI tree dumps (JSON) via stdin or a file path and emit a filtered tree to stdout for downstream tooling.
+- Offer flexible filtering primitives so the tool can be chained with Robot Framework suites or debugging scripts.
+
+## 3. Data Model and Parsing Strategy
+- Parse UI hierarchies into a `UiNode` structure containing `id`, `role`, optional `name`, optional `properties`, and recursive `children` nodes.
+- Support both single-root (`{ ... }`) and forest (`[{ ... }]`) JSON payloads to accommodate different exporters.
+- Preserve property order deterministically using `BTreeMap` to yield stable textual output for tests and diff tooling.
+
+## 4. Filtering Capabilities
+- Role filtering (`--role <value>`) with optional case-insensitive comparison for interoperability across platforms.
+- Name matching via regular expressions with optional case folding (`--name-pattern`, `--ignore-name-case`).
+- Arbitrary property matchers supplied as `--property key=value` pairs that ensure exact matches against node metadata.
+- Depth limiting (`--max-depth`) to truncate noisy hierarchies while still showing ancestor context.
+- Filtering retains ancestors of matching nodes to preserve navigational context even when the ancestor itself fails the predicate.
+
+## 5. Output Modes
+- Text mode (default) renders an ASCII tree (`├──`, `└──`) with optional property sections when `--include-properties` is passed.
+- JSON mode (`--format json`) prints the filtered tree back as formatted JSON for machine consumers or regression snapshots.
+
+## 6. Error Handling
+- Invalid JSON payloads or regex patterns bubble up as actionable error messages while still exiting with a non-zero status code.
+- Improper `--property` arguments (missing `=`) are rejected by clap before the tool attempts to parse the payload.
+
+## 7. Testing Strategy
+- **Unit tests** exercise the filtering engine: role filtering, regex name matching, property matching, and depth truncation.
+- **Integration tests** (via `assert_cmd`) run the compiled binary against a fixture UI tree to verify end-to-end behaviour for text output, JSON mode, and input validation failure paths.
+- The CI workflow runs `cargo fmt`, `cargo clippy`, and `cargo test` to keep style and lints enforced alongside functional coverage.
+
+## 8. Delivery Steps
+1. Scaffold the Rust crate and define the data model and filter engine inside `src/lib.rs`.
+2. Implement the CLI front end with clap argument parsing in `src/main.rs`.
+3. Add fixtures and integration tests under `tests/` to validate CLI behaviour.
+4. Document the plan (this file) and reference it from contributor documentation if necessary.
+5. Add a dedicated GitHub Actions workflow to build, lint, and test the crate on every push and pull request.

--- a/spy-cli/Cargo.toml
+++ b/spy-cli/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "spy-cli"
+version = "0.1.0"
+edition = "2024"
+authors = ["robotframework-PlatynUI Contributors"]
+description = "Command line spy tool for inspecting UI trees"
+license = "Apache-2.0"
+
+[dependencies]
+clap = { version = "4.5", features = ["derive"] }
+regex = "1.10"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+anyhow = "1.0"
+
+[dev-dependencies]
+assert_cmd = "2.0"
+predicates = "3.1"

--- a/spy-cli/src/lib.rs
+++ b/spy-cli/src/lib.rs
@@ -1,0 +1,347 @@
+use std::collections::BTreeMap;
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SpyError {
+    #[error("failed to parse ui tree: {0}")]
+    ParseError(#[from] serde_json::Error),
+    #[error("invalid name pattern: {0}")]
+    InvalidPattern(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UiNode {
+    pub id: String,
+    pub role: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub properties: BTreeMap<String, Value>,
+    #[serde(default)]
+    pub children: Vec<UiNode>,
+}
+
+impl UiNode {
+    fn matches(&self, filter: &FilterCriteria, depth: usize) -> bool {
+        if let Some(max_depth) = filter.max_depth {
+            if depth > max_depth {
+                return false;
+            }
+        }
+
+        if !filter.roles.is_empty() {
+            let node_role = if filter.ignore_role_case {
+                self.role.to_lowercase()
+            } else {
+                self.role.clone()
+            };
+
+            let mut role_matches = false;
+            for role in &filter.roles {
+                if filter.ignore_role_case {
+                    if node_role == *role {
+                        role_matches = true;
+                        break;
+                    }
+                } else if &self.role == role {
+                    role_matches = true;
+                    break;
+                }
+            }
+
+            if !role_matches {
+                return false;
+            }
+        }
+
+        if let Some(ref pattern) = filter.compiled_name_pattern {
+            let name = self.name.as_deref().unwrap_or("");
+            if !pattern.is_match(name) {
+                return false;
+            }
+        }
+
+        for (key, expected_value) in &filter.properties {
+            let Some(value) = self.properties.get(key) else {
+                return false;
+            };
+            let matches = value
+                .as_str()
+                .map(|s| s == expected_value)
+                .unwrap_or_else(|| value.to_string() == *expected_value);
+            if !matches {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct FilterCriteria {
+    pub roles: Vec<String>,
+    pub name_pattern: Option<String>,
+    pub compiled_name_pattern: Option<Regex>,
+    pub properties: BTreeMap<String, String>,
+    pub max_depth: Option<usize>,
+    pub include_properties: bool,
+    pub ignore_role_case: bool,
+    pub ignore_name_case: bool,
+}
+
+impl FilterCriteria {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn compile(&mut self) -> Result<(), SpyError> {
+        if let Some(pattern) = &self.name_pattern {
+            let regex_source = if self.ignore_name_case {
+                format!("(?i){pattern}")
+            } else {
+                pattern.clone()
+            };
+            let regex = Regex::new(&regex_source)
+                .map_err(|err| SpyError::InvalidPattern(err.to_string()))?;
+            self.compiled_name_pattern = Some(regex);
+        }
+        if self.ignore_role_case {
+            self.roles = self.roles.iter().map(|role| role.to_lowercase()).collect();
+        }
+        Ok(())
+    }
+}
+
+pub fn load_ui_tree_from_str(raw: &str) -> Result<Vec<UiNode>, SpyError> {
+    if raw.trim_start().starts_with('[') {
+        Ok(serde_json::from_str::<Vec<UiNode>>(raw)?)
+    } else if raw.trim().is_empty() {
+        Ok(Vec::new())
+    } else {
+        let node = serde_json::from_str::<UiNode>(raw)?;
+        Ok(vec![node])
+    }
+}
+
+pub fn filter_tree(nodes: &[UiNode], criteria: &FilterCriteria) -> Result<Vec<UiNode>, SpyError> {
+    let mut criteria = criteria.clone();
+    criteria.compile()?;
+
+    let filtered = nodes
+        .iter()
+        .filter_map(|node| filter_node(node, &criteria, 0))
+        .collect();
+    Ok(filtered)
+}
+
+fn filter_node(node: &UiNode, criteria: &FilterCriteria, depth: usize) -> Option<UiNode> {
+    if let Some(max_depth) = criteria.max_depth {
+        if depth > max_depth {
+            return None;
+        }
+    }
+
+    let mut filtered_children = Vec::new();
+    if criteria.max_depth.map(|max| depth < max).unwrap_or(true) {
+        filtered_children = node
+            .children
+            .iter()
+            .filter_map(|child| filter_node(child, criteria, depth + 1))
+            .collect();
+    }
+
+    let matches = node.matches(criteria, depth);
+    if matches || !filtered_children.is_empty() {
+        Some(UiNode {
+            id: node.id.clone(),
+            role: node.role.clone(),
+            name: node.name.clone(),
+            properties: node.properties.clone(),
+            children: filtered_children,
+        })
+    } else {
+        None
+    }
+}
+
+pub fn format_tree_text(nodes: &[UiNode], include_properties: bool) -> String {
+    let mut output = String::new();
+    for (index, node) in nodes.iter().enumerate() {
+        format_node_text(
+            node,
+            0,
+            include_properties,
+            index == nodes.len() - 1,
+            &mut output,
+            String::new(),
+        );
+    }
+    output.trim_end().to_string()
+}
+
+fn format_node_text(
+    node: &UiNode,
+    depth: usize,
+    include_properties: bool,
+    is_last: bool,
+    output: &mut String,
+    prefix: String,
+) {
+    let connector = if depth == 0 {
+        String::new()
+    } else if is_last {
+        format!("{prefix}└── ")
+    } else {
+        format!("{prefix}├── ")
+    };
+
+    let label = match (&node.name, include_properties) {
+        (Some(name), _) => format!(
+            "[{role}] {name} <{id}>",
+            role = node.role,
+            name = name,
+            id = node.id
+        ),
+        (None, _) => format!("[{role}] <{id}>", role = node.role, id = node.id),
+    };
+    output.push_str(&connector);
+    output.push_str(&label);
+    output.push('\n');
+
+    if include_properties && !node.properties.is_empty() {
+        let props_prefix = format!(
+            "{prefix}{}",
+            if depth == 0 {
+                "    "
+            } else if is_last {
+                "    "
+            } else {
+                "│   "
+            }
+        );
+        for (key, value) in &node.properties {
+            output.push_str(&format!("{props_prefix}{key}: {value}\n"));
+        }
+    }
+
+    let child_prefix = if depth == 0 {
+        String::from("")
+    } else if is_last {
+        format!("{prefix}    ")
+    } else {
+        format!("{prefix}│   ")
+    };
+
+    for (index, child) in node.children.iter().enumerate() {
+        format_node_text(
+            child,
+            depth + 1,
+            include_properties,
+            index == node.children.len() - 1,
+            output,
+            child_prefix.clone(),
+        );
+    }
+}
+
+pub fn format_tree_json(nodes: &[UiNode]) -> Result<String, SpyError> {
+    Ok(serde_json::to_string_pretty(nodes)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_tree() -> Vec<UiNode> {
+        serde_json::from_str(
+            r#"
+            [
+                {
+                    "id": "root",
+                    "role": "window",
+                    "name": "Calculator",
+                    "properties": {"AutomationId": "rootWindow"},
+                    "children": [
+                        {
+                            "id": "btn-1",
+                            "role": "button",
+                            "name": "One",
+                            "properties": {"AutomationId": "num1Button"},
+                            "children": []
+                        },
+                        {
+                            "id": "btn-2",
+                            "role": "button",
+                            "name": "Two",
+                            "properties": {"AutomationId": "num2Button"},
+                            "children": []
+                        },
+                        {
+                            "id": "panel",
+                            "role": "group",
+                            "name": "Memory",
+                            "properties": {},
+                            "children": [
+                                {
+                                    "id": "lbl",
+                                    "role": "text",
+                                    "name": "M+",
+                                    "properties": {"Shortcut": "Ctrl+M"},
+                                    "children": []
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+            "#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn filters_by_role() {
+        let tree = sample_tree();
+        let mut criteria = FilterCriteria::new();
+        criteria.roles = vec!["button".to_string()];
+        let filtered = filter_tree(&tree, &criteria).unwrap();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].children.len(), 2);
+        assert!(
+            filtered[0]
+                .children
+                .iter()
+                .all(|node| node.role == "button")
+        );
+    }
+
+    #[test]
+    fn filters_by_name_regex() {
+        let tree = sample_tree();
+        let mut criteria = FilterCriteria::new();
+        criteria.name_pattern = Some("^M".to_string());
+        let filtered = filter_tree(&tree, &criteria).unwrap();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].children.len(), 1);
+        assert_eq!(filtered[0].children[0].name.as_deref(), Some("Memory"));
+    }
+
+    #[test]
+    fn respects_property_filters() {
+        let tree = sample_tree();
+        let mut criteria = FilterCriteria::new();
+        criteria
+            .properties
+            .insert("AutomationId".into(), "num2Button".into());
+        let filtered = filter_tree(&tree, &criteria).unwrap();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].children.len(), 1);
+        assert_eq!(filtered[0].children[0].id, "btn-2");
+    }
+}

--- a/spy-cli/src/main.rs
+++ b/spy-cli/src/main.rs
@@ -1,0 +1,106 @@
+use std::fs;
+use std::io::{self, Read};
+use std::path::PathBuf;
+
+use clap::{Parser, ValueEnum};
+use spy_cli::{
+    FilterCriteria, filter_tree, format_tree_json, format_tree_text, load_ui_tree_from_str,
+};
+
+#[derive(Debug, Clone, ValueEnum)]
+enum OutputFormat {
+    Text,
+    Json,
+}
+
+#[derive(Parser, Debug)]
+#[command(author, version, about = "PlatynUI command line spy tool", long_about = None)]
+struct Cli {
+    /// Optional path to a JSON file containing a UI tree dump
+    #[arg(short, long)]
+    input: Option<PathBuf>,
+
+    /// Restrict the output to nodes at or above this depth (root = 0)
+    #[arg(short = 'd', long = "max-depth")]
+    max_depth: Option<usize>,
+
+    /// Only include nodes whose role matches one of the provided values
+    #[arg(short, long = "role")]
+    roles: Vec<String>,
+
+    /// Only include nodes whose name matches the provided regular expression
+    #[arg(short, long = "name-pattern")]
+    name_pattern: Option<String>,
+
+    /// Treat role filters as case-insensitive
+    #[arg(long = "ignore-role-case")]
+    ignore_role_case: bool,
+
+    /// Treat name pattern filter as case-insensitive by wrapping it into (?i)
+    #[arg(long = "ignore-name-case")]
+    ignore_name_case: bool,
+
+    /// Require nodes to contain these property key=value pairs
+    #[arg(long = "property", value_parser = parse_property)]
+    properties: Vec<(String, String)>,
+
+    /// Include serialized properties in textual output
+    #[arg(long = "include-properties")]
+    include_properties: bool,
+
+    /// Select the desired output format
+    #[arg(long = "format", default_value_t = OutputFormat::Text)]
+    format: OutputFormat,
+}
+
+fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    let mut buffer = String::new();
+    if let Some(input_path) = cli.input {
+        buffer = fs::read_to_string(input_path)?;
+    } else {
+        io::stdin().read_to_string(&mut buffer)?;
+    }
+
+    let mut criteria = FilterCriteria::new();
+    criteria.max_depth = cli.max_depth;
+    criteria.include_properties = cli.include_properties;
+    criteria.ignore_role_case = cli.ignore_role_case;
+    criteria.ignore_name_case = cli.ignore_name_case;
+    for role in cli.roles {
+        criteria.roles.push(role);
+    }
+    if let Some(pattern) = cli.name_pattern {
+        criteria.name_pattern = Some(pattern);
+    }
+    for (key, value) in cli.properties {
+        criteria.properties.insert(key, value);
+    }
+
+    let tree = load_ui_tree_from_str(&buffer)?;
+    let filtered = filter_tree(&tree, &criteria)?;
+
+    match cli.format {
+        OutputFormat::Text => {
+            let output = format_tree_text(&filtered, criteria.include_properties);
+            println!("{}", output);
+        }
+        OutputFormat::Json => {
+            let output = format_tree_json(&filtered)?;
+            println!("{}", output);
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_property(raw: &str) -> Result<(String, String), String> {
+    let (key, value) = raw
+        .split_once('=')
+        .ok_or_else(|| "properties must be expressed as key=value".to_string())?;
+    if key.trim().is_empty() {
+        return Err("property key must not be empty".into());
+    }
+    Ok((key.trim().to_string(), value.trim().to_string()))
+}

--- a/spy-cli/tests/cli.rs
+++ b/spy-cli/tests/cli.rs
@@ -1,0 +1,53 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::path::PathBuf;
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+#[test]
+fn prints_tree_in_text_format() {
+    let mut cmd = Command::cargo_bin("spy-cli").unwrap();
+    cmd.arg("--input")
+        .arg(fixture_path("sample_tree.json"))
+        .arg("--include-properties");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("[window] Calculator"))
+        .stdout(predicate::str::contains("AutomationId: \"rootWindow\""));
+}
+
+#[test]
+fn filters_with_role_and_max_depth() {
+    let mut cmd = Command::cargo_bin("spy-cli").unwrap();
+    cmd.arg("--input")
+        .arg(fixture_path("sample_tree.json"))
+        .arg("--role")
+        .arg("button")
+        .arg("--max-depth")
+        .arg("2")
+        .arg("--format")
+        .arg("json");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("\"role\": \"button\""))
+        .stdout(predicate::str::contains("\"name\": \"+\""));
+}
+
+#[test]
+fn rejects_invalid_property_argument() {
+    let mut cmd = Command::cargo_bin("spy-cli").unwrap();
+    cmd.arg("--input")
+        .arg(fixture_path("sample_tree.json"))
+        .arg("--property")
+        .arg("missing-value");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("key=value"));
+}

--- a/spy-cli/tests/fixtures/sample_tree.json
+++ b/spy-cli/tests/fixtures/sample_tree.json
@@ -1,0 +1,48 @@
+[
+  {
+    "id": "root",
+    "role": "window",
+    "name": "Calculator",
+    "properties": {
+      "AutomationId": "rootWindow",
+      "ProcessId": 420
+    },
+    "children": [
+      {
+        "id": "display",
+        "role": "text",
+        "name": "Display",
+        "properties": {
+          "Value": "0"
+        },
+        "children": []
+      },
+      {
+        "id": "num-5",
+        "role": "button",
+        "name": "5",
+        "properties": {
+          "AutomationId": "num5Button"
+        },
+        "children": []
+      },
+      {
+        "id": "operators",
+        "role": "group",
+        "name": "Operators",
+        "properties": {},
+        "children": [
+          {
+            "id": "plus",
+            "role": "button",
+            "name": "+",
+            "properties": {
+              "AutomationId": "plusButton"
+            },
+            "children": []
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- document a detailed plan for delivering a Rust-based command-line spy companion
- add the new `spy-cli` crate with JSON parsing, filtering, and formatting logic plus integration tests
- introduce a Rust-focused GitHub Actions workflow and README guidance for running the tool

## Testing
- cargo fmt --manifest-path spy-cli/Cargo.toml
- cargo clippy --manifest-path spy-cli/Cargo.toml --all-targets --all-features *(fails: crates.io unreachable in the execution environment)*
- cargo test --manifest-path spy-cli/Cargo.toml --all-targets *(fails: crates.io unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8398f636c8331aa746290caaf288a